### PR TITLE
[v2.10.2] Fix Bloom bug and Add Help Document

### DIFF
--- a/Runtime/Passes/PostProcessPass.cs
+++ b/Runtime/Passes/PostProcessPass.cs
@@ -297,6 +297,7 @@ namespace HSR.NPRShader.Passes
                 CoreUtils.SetKeyword(material, ShaderKeywordStrings.UseRGBM, m_UseRGBM);
 
                 cmd.SetGlobalFloat(PropertyIds._BloomThreshold, m_BloomConfig.Threshold.value);
+                cmd.SetGlobalFloat(PropertyIds._BloomClampMax, m_BloomConfig.Clamp.value);
                 cmd.SetGlobalVectorArray(PropertyIds._BloomUVMinMax, m_BloomAtlasUVMinMax);
 
                 // Prefilter
@@ -407,6 +408,7 @@ namespace HSR.NPRShader.Passes
         private static class PropertyIds
         {
             public static readonly int _BloomThreshold = MemberNameHelpers.ShaderPropertyID();
+            public static readonly int _BloomClampMax = MemberNameHelpers.ShaderPropertyID();
             public static readonly int _BloomUVMinMax = MemberNameHelpers.ShaderPropertyID();
             public static readonly int _BloomUVIndex = MemberNameHelpers.ShaderPropertyID();
             public static readonly int _BloomKernelSize = MemberNameHelpers.ShaderPropertyID();

--- a/Runtime/PostProcessing/CustomBloom.cs
+++ b/Runtime/PostProcessing/CustomBloom.cs
@@ -28,11 +28,13 @@ using UnityEngine.Rendering.Universal;
 namespace HSR.NPRShader.PostProcessing
 {
     [Serializable]
+    [HelpURL("https://github.com/stalomeow/StarRailNPRShader/blob/main/README.md")]
     [VolumeComponentMenuForRenderPipeline("Honkai Star Rail/Bloom", typeof(UniversalRenderPipeline))]
     public class CustomBloom : VolumeComponent, IPostProcessComponent
     {
         public MinFloatParameter Intensity = new(0, 0);
         public MinFloatParameter Threshold = new(0.7f, 0);
+        public MinFloatParameter Clamp = new(65472.0f, 0);
         public ColorParameter Tint = new(Color.white, false, false, true);
         public ClampedIntParameter MipDownCount = new(2, 2, 4);
         public BoolParameter CharactersOnly = new(true, BoolParameter.DisplayType.EnumPopup);

--- a/Runtime/PostProcessing/CustomTonemapping.cs
+++ b/Runtime/PostProcessing/CustomTonemapping.cs
@@ -27,6 +27,7 @@ using UnityEngine.Rendering.Universal;
 namespace HSR.NPRShader.PostProcessing
 {
     [Serializable]
+    [HelpURL("https://github.com/stalomeow/StarRailNPRShader/blob/main/README.md")]
     [VolumeComponentMenuForRenderPipeline("Honkai Star Rail/Tonemapping", typeof(UniversalRenderPipeline))]
     public class CustomTonemapping : VolumeComponent, IPostProcessComponent
     {

--- a/Shaders/Postprocessing/Bloom.shader
+++ b/Shaders/Postprocessing/Bloom.shader
@@ -52,6 +52,7 @@ Shader "Hidden/Honkai Star Rail/Post Processing/Bloom"
         float4 _BlitTexture_TexelSize;
 
         float _BloomThreshold;
+        float _BloomClampMax;
         float4 _BloomUVMinMax[MAX_MIP_DOWN_BLUR_COUNT];
 
         int _BloomUVIndex;
@@ -100,6 +101,10 @@ Shader "Hidden/Honkai Star Rail/Post Processing/Bloom"
 #endif
 
             float3 color = SAMPLE_TEXTURE2D_X(_BlitTexture, sampler_LinearClamp, uv).rgb;
+
+            // User controlled clamp to limit crazy high broken spec
+            color = min(_BloomClampMax, color);
+
             color = max(0, color - _BloomThreshold.rrr);
             return EncodeHDR(color);
         }


### PR DESCRIPTION
添加了帮助文档，给bloom加了个clamp，防止高光部分过曝。对比下修改前后效果
Before：
![image](https://github.com/user-attachments/assets/1869dea0-a69c-40e1-b577-3a5a5500e5c7)

After：
![image](https://github.com/user-attachments/assets/ac08ecc9-d6c7-4ee0-bef0-69c8699a15d1)

